### PR TITLE
Return an error if we don't match anything

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -31,7 +31,11 @@ var bootstrap = `
 	if [ -z "$CDDIR" ]; then
 		cd $(%s jig root)
 	else
-		cd $(%s jig ls -n1 $CDDIR)
+		DESTDIR=$(%s jig ls -n1 $CDDIR)
+		if [ -z "$DESTDIR" ]; then
+			return 1
+		fi
+		cd $DESTDIR
 	fi
 }
 `


### PR DESCRIPTION
"cd asdasd" will change directory to your home directory.  Instead,
this change returns an error if the repo can't be found.